### PR TITLE
fix: Use `TMPDIR` if it is not empty

### DIFF
--- a/tmpsms
+++ b/tmpsms
@@ -7,7 +7,7 @@ VERSION="1.0.0"
 
 # Everything related to 'tmpsms' will be stored in this directory. Once the
 # computer get restarted, this directory gets deleted.
-TMPSMS_DIR="/tmp/tmpsms"
+TMPSMS_DIR="${TMPDIR:-/tmp}/tmpsms"
 
 # The phone number that the user has selected gets stored in this file so that
 # the do not have reselect at ever run.


### PR DESCRIPTION
I know `tmpsms` no longer works, but people will invariably be reading the script anyways, and I think it's good to show good practices, like the reading of `TMPDIR`.

Closes #12 (spam)